### PR TITLE
FIx misaligned inner corner of hamburger menu in navigation.css

### DIFF
--- a/src/css/layout/navigation.css
+++ b/src/css/layout/navigation.css
@@ -151,7 +151,7 @@ nav .menu-icon.close {
     border-radius: 0 20px 0 0;
     box-shadow: 5px 0px #fff, inset -1px 1px 3px rgba(253, 204, 204, 0.3);
     height: 15px;
-    width: 66vw;
+    width: 202.5%;
   }
 
   nav.closed ul:before {

--- a/src/css/layout/navigation.css
+++ b/src/css/layout/navigation.css
@@ -179,6 +179,6 @@ nav .menu-icon.close {
 
   nav ul::before {
     left: -102%;
-    width: 50vw;
+    width: 101.5%;
   }
 }


### PR DESCRIPTION
this small edit fixes the misaligned inner corner on the hamburger dropdown menu by matching the width of `nav ul::before` with its negative left positioning (minus a fudge factor for rounding variances).

<img width="590" alt="rubycentral - misaligned inner corner of hamburger menu - 20230514" src="https://github.com/rubycentral/rubycentral-theme/assets/950439/bf40e1eb-23fc-4c3a-a267-b171c2cce0a4">
