### PR TITLE
Home page copy update

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -13,16 +13,10 @@
     <div>
       <section id="blurb">
         <div class="icon-box"></div>
-        <h4>
-          Ruby Central is a non-profit organization dedicated to Ruby support
-          and advocacy of the worldwide Ruby community.
-        </h4>
         <p>
-          We organize the annual RubyConf and RailsConf software conferences,
-          support community growth, and provide vital infrastructure for the
-          Ruby programming language.
+          Ruby Central is a non-profit organization dedicated to supporting the worldwide Ruby community. We organize the annual RubyConf and RailsConf software conferences, support community growth, and provide vital infrastructure for the Ruby programming language. 
         </p>
-        <p><a href="#about">Learn more about us.</a></p>
+        <p>{{#link href="/history"}}Learn more about us.{{/link}}</p>
       </section>
       <section id="rubygems">
         <div class="section-header">
@@ -41,53 +35,27 @@
       </section>
     </div>
     <div>
-      <section id="community">
+       <section id="support">
         <div class="section-header">
           <div class="icon-box"></div>
-          <h3>Community</h3>
+          <h3>Supporting Ruby Central, Inc</h3>
           <img src="{{asset "images/arrow.svg"}}" class="arrow">
         </div>
         <p>
-          Here at Ruby Central, we’re incredibly appreciative of our
-          community, which is dedicated to maintaining an open, welcoming, and
-          supportive environment for all Rubyists. As such, we’re always
-          excited to hear about new Ruby-related projects and regional
-          conferences.
+          The Ruby language could only have developed so robustly with its dedicated community. Our community consists of talented and passionate individual developers and many dynamic companies that recognize the value of helping foster a strong, sustainable environment for Ruby development. Join our {{#link href="/#/portal/signup"}}Member Community{{/link}}, <strong>Become a Sponsor</strong>, or donate your time –there are numerous ways to {{#link href="/support"}}Support Us{{/link}}!
         </p>
+        <p></p>
 
         <p>
-          In some instances, we are able to provide resources, grants, or
-          other forms of assistance. If you have a project or conference that
-          you think we should know about, please don’t hesitate to
-          <a href="mailto:contact@rubycentral.org">contact us</a>.
+          If you are looking for ways to help or have questions, please contact us at {{#link href="mailto:contact@rubycentral.org"}}contact@rubycentral.org{{/link}}.
         </p>
       </section>
+
       <section id="conferences">
         <h3>33 Conferences and counting.</h3>
       </section>
     </div>
   </div>
-  <section id="support">
-    <div class="section-header">
-      <div class="icon-box"></div>
-      <h3>Support</h3>
-      <img src="{{asset "images/arrow.svg"}}" class="arrow">
-    </div>
-    <p>
-      The Ruby language could not have developed so robustly without its
-      dedicated community. This community consists of not only talented and
-      passionate individual developers, but also many dynamic companies that
-      recognize the value of helping foster a strong, sustainable environment
-      for Ruby development.
-    </p>
-    <p></p>
-
-    <p>
-      If you are looking for ways in which you can help us support the Ruby
-      community, please contact us at
-      <a href="mailto:contact@rubycentral.org">contact@rubycentral.org</a>.
-    </p>
-  </section>
   <div class="main-grid">
     <div>
       <section id="rubyconf" class="light-background">
@@ -104,91 +72,7 @@
           the community’s leading minds, including Yukihiro Matsumoto
           ("Matz"), the creator of the Ruby language.
         </p>
-        <ul class="conference-list">
-          <li>
-            San Diego 2023
-          </li>
-          <li>
-      Houston 2022<a href="https://www.youtube.com/playlist?list=PLbHJudTY1K0dERpqJUEFOFSsMGvR6st9U"></a>
-          </li>
-          <li>
-            Denver 2021<a
-                            href="https://www.youtube.com/watch?v=sAu8UUnVc_Y&list=PLE7tQUdRKcyYVnWhDQk4RCPVlMW40I6s5"
-                            ></a>
-          </li>
-          <li>
-            Virtual 2020<a
-                            href="https://www.youtube.com/watch?v=FTWKackp1Js&list=PLbHJudTY1K0cyDs1ZwFLzlfQqvkDKt17N"
-                            ></a>
-          </li>
-          <li>
-            Nashville 2019<a
-                            href="https://www.youtube.com/watch?v=2g9R7PUCEXo&list=PLE7tQUdRKcyZDE8nFrKaqkpd-XK4huygU"
-                            ></a>
-          </li>
-          <li>
-            Los Angeles 2018<a
-                              href="http://confreaks.tv/events/rubyconf2018"
-                              ></a>
-          </li>
-          <li>
-            New Orleans 2017<a
-                              href="http://confreaks.tv/events/rubyconf2017"
-                              ></a>
-          </li>
-          <li>
-            Cincinnati 2016<a
-                            href="http://confreaks.tv/events/rubyconf2016"
-                            ></a>
-          </li>
-          <li>
-            San Antonio 2015<a
-                              href="http://confreaks.tv/events/rubyconf2015"
-                              ></a>
-          </li>
-          <li>
-            San Diego 2014<a
-                            href="http://confreaks.tv/events/rubyconf2014"
-                            ></a>
-          </li>
-          <li>
-            Miami Beach 2013<a
-                              href="http://confreaks.tv/events/rubyconf2013"
-                              ></a>
-          </li>
-          <li>
-            Denver 2012<a href="http://confreaks.tv/events/rubyconf2012"></a>
-          </li>
-          <li>
-            New Orleans 2011<a
-                              href="http://confreaks.tv/events/rubyconf2011"
-                              ></a>
-          </li>
-          <li>
-            New Orleans 2010<a
-                              href="http://confreaks.tv/events/rubyconf2010"
-                              ></a>
-          </li>
-          <li>
-            San Francisco 2009<a
-                                href="http://confreaks.tv/events/rubyconf2009"
-                                ></a>
-          </li>
-          <li>
-            Orlando 2008<a href="http://confreaks.tv/events/rubyconf2008"></a>
-          </li>
-          <li>
-            Charlotte 2007<a
-                            href="http://confreaks.tv/events/rubyconf2007"
-                            ></a>
-          </li>
-          <li>Denver 2006</li>
-          <li>San Diego 2005</li>
-          <li>Reston 2004</li>
-          <li>Austin 2003</li>
-          <li>Seattle 2002</li>
-          <li>Tampa 2001</li>
-        </ul>
+        <p>{{#link href="/conferences"}}Learn more{{/link}}</p>
       </section>
     </div>
     <div>
@@ -205,80 +89,7 @@
           applications. With a specific focus on Rails, conference topics can
           range from new users to administration to advanced techniques.
         </p>
-        <ul class="conference-list">
-          <li>
-            Atlanta 2023
-          </li>
-          <li>
-            Portland 2022<a
-                              href="https://www.youtube.com/playlist?list=PLbHJudTY1K0f1WgIbKCc0_M-XMraWwCmk"
-                              ></a>
-          </li>
-          <li>
-            Virtual 2021<a
-                              href="https://www.youtube.com/watch?v=TNFljhcoHvQ&list=PLE7tQUdRKcyan3isUPgB_fER4eM9Js6pA"
-                              ></a>
-          </li>
-          <li>
-            Virtual 2020<a
-                              href="https://www.youtube.com/playlist?list=PLE7tQUdRKcyZ-TzxlxdLvh6tDUfZHqm76"
-                              ></a>
-          </li>
-          <li>
-            Minneapolis 2019<a
-                              href="https://www.youtube.com/playlist?list=PLE7tQUdRKcyaOq3HlRm9h_Q_WhWKqm5xc"
-                              ></a>
-          </li>
-          <li>
-            Pittsburgh 2018<a
-                            href="http://confreaks.tv/events/railsconf2018"
-                            ></a>
-          </li>
-          <li>
-            Phoenix 2017<a
-                          href="http://confreaks.tv/events/railsconf2017"
-                          ></a>
-          </li>
-          <li>
-            Kansas City 2016<a
-                              href="http://confreaks.tv/events/railsconf2016"
-                              ></a>
-          </li>
-          <li>
-            Atlanta 2015<a
-                          href="http://confreaks.tv/events/railsconf2015"
-                          ></a>
-          </li>
-          <li>
-            Chicago 2014<a
-                          href="https://www.youtube.com/playlist?list=PLE7tQUdRKcyZ5jfnbS_osIoWzK_FrwKz5"
-                          ></a>
-          </li>
-          <li>
-            Portland 2013<a
-                          href="https://www.youtube.com/playlist?list=PLE7tQUdRKcybxgqVTwuOA12wr5Gn2M2Pp"
-                          ></a>
-          </li>
-          <li>
-            Austin 2012<a
-                        href="https://www.youtube.com/playlist?list=PLF16D2F3A8469021E"
-                        ></a>
-          </li>
-          <li>
-            Baltimore 2011<a
-                            href="https://www.youtube.com/playlist?list=PL379EA9290474C86C"
-                            ></a>
-          </li>
-          <li>
-            Baltimore 2010<a
-                            href="https://www.youtube.com/playlist?list=PL393ECE649BB3813D"
-                            ></a>
-          </li>
-          <li>Las Vegas 2009</li>
-          <li>Portland 2008</li>
-          <li>Portland 2007</li>
-          <li>Chicago 2006</li>
-        </ul>
+        <p>{{#link href="/conferences"}}Learn more{{/link}}</p>
       </section>
     </div>
   </div>
@@ -312,19 +123,5 @@
       {{/get}}
       </ul>
     </div>
-  </div>
-</div>
-
-<div id="history">
-  <div class="content padded-container">
-    <div class="icon-box"></div>
-    {{#get "pages" limit="1" filter="title:History"}}
-      {{#foreach pages}}
-        <h3>{{title}}</h3>
-        {{content}}
-      {{else}}
-        <p>Create a page titled "History" and its contents will appear here!</p>
-      {{/foreach}}
-    {{/get}}
   </div>
 </div>

--- a/src/css/rubycentral.css
+++ b/src/css/rubycentral.css
@@ -20,11 +20,6 @@
   text-shadow: 0 2px 0 var(--red), 1px 2px 0 var(--red), -1px 2px 0 var(--red), 2px 2px 0 var(--red), -2px 2px 0 var(--red);
 }
 
-#community a {
-  color: var(--white);
-  text-shadow: 0 2px 0 var(--purple), 1px 2px 0 var(--purple), -1px 2px 0 var(--purple), 2px 2px 0 var(--purple), -2px 2px 0 var(--purple);
-}
-
 #rubygems a {
   color: var(--white);
   text-shadow: 0 2px 0 var(--green), 1px 2px 0 var(--green), -1px 2px 0 var(--green), 2px 2px 0 var(--green), -2px 2px 0 var(--green);
@@ -327,7 +322,7 @@ header h2 {
 
 .main-grid {
   max-width: 950px;
-  margin: 0 auto;
+  margin: 0 auto 50px auto;
   display: grid;
   gap: 50px;
   grid-template-columns: 1fr 1fr;
@@ -385,20 +380,13 @@ h3 {
   background: url(/assets/images/blurb-icon.svg) center center no-repeat, linear-gradient(to top, #DF3434 0%, #FB5E55 100%);
 }
 
-#community {
-  background-color: var(--purple);
+#support {
+  background-color: var(--blue);
 }
 
-#community h5 {
-  font-size: 16px;
-  font-family: 'Rubik';
-  margin: 0 0 5px 0;
-  font-weight: 600;
-}
-
-#community .icon-box {
-  box-shadow: 0 9px 18px rgba(77, 50, 89, 0.45), 0 1px 5px rgba(132, 69, 141, 0.21);
-  background: url(/assets/images/community-icon.svg) center center no-repeat, linear-gradient(to top, #6D4D7C 0%, #7E5B8D 100%);
+#support .icon-box {
+  box-shadow: 0 9px 18px rgba(15, 35, 63, 0.14), 0 1px 5px rgba(23, 43, 69, 0.12);
+  background: url(/assets/images/support-icon.svg) center center no-repeat, linear-gradient(to top, #5A81B7 0%, #6992CA 100%);
 }
 
 #rubygems {
@@ -417,18 +405,6 @@ h3 {
 
 #conferences h3 {
   margin: 0;
-}
-
-#support {
-  max-width: 950px;
-  padding: 50px 150px;
-  margin: 50px auto;
-  background-color: var(--blue);
-}
-
-#support .icon-box {
-  box-shadow: 0 9px 18px rgba(15, 35, 63, 0.14), 0 1px 5px rgba(23, 43, 69, 0.12);
-  background: url(/assets/images/support-icon.svg) center center no-repeat, linear-gradient(to top, #5A81B7 0%, #6992CA 100%);
 }
 
 #rubyconf .icon-box {
@@ -475,42 +451,6 @@ h3 {
   100% {
     background-position: 5px center;
   }
-}
-
-.conference-list {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.conference-list li {
-  height: 48px;
-  line-height: 48px;
-  position: relative;
-  margin: 0;
-  padding: 0;
-  border-bottom: 1px solid var(--divider);
-}
-
-.conference-list li:last-child {
-  border: none;
-}
-
-.conference-list li a {
-  box-shadow: none !important;
-  position: absolute;
-  right: 0;
-  top: 13px;
-  height: 22px;
-  width: 27px;
-  border: 2px solid #5E83A7;
-  border-radius: 5px;
-  background: url(/assets/images/video-icon.svg) 5px center no-repeat;
-  animation: video_hover_out .2s linear;
-}
-
-.conference-list li a:hover {
-  animation: video_hover .2s linear;
 }
 
 .content {
@@ -836,6 +776,7 @@ h3 {
     width: auto;
     display: block;
     padding: 0 20px;
+    margin: unset;
   }
 
   .main-grid section {
@@ -909,11 +850,8 @@ h3 {
 
   #support {
     width: auto;
-    margin: 0 20px 20px 20px;
     padding: 25px;
     position: relative;
-    height: 114px;
-    max-height: 114px;
     overflow: hidden;
     transition: all .5s ease-in-out;
   }


### PR DESCRIPTION
🟢 - Ready for review/merge
# Reason for Change
The home page requires some copy updates. 

## Description of Change
1. Update the text within the red 'Ruby Central Info block'
2. Remove the purple 'Community' section, and replace it with the existing blue 'Support' section.
  - Additionally update the support copy as requested.
3. Remove the 'History' section at the bottom of the page.
4. Remove the links to the previous conference's.
  - In their place add 'Learn More' links that direct to the '/conferences'
  
These changes were requested by Ally Vogel via Asana, and were tracked via this [TODO](https://app.asana.com/0/1202521178011220/1204809963819726) 


