### PR TITLE
Add link to home page support section

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -42,10 +42,9 @@
           <img src="{{asset "images/arrow.svg"}}" class="arrow">
         </div>
         <p>
-          The Ruby language could only have developed so robustly with its dedicated community. Our community consists of talented and passionate individual developers and many dynamic companies that recognize the value of helping foster a strong, sustainable environment for Ruby development. Join our {{#link href="/#/portal/signup"}}Member Community{{/link}}, <strong>Become a Sponsor</strong>, or donate your time –there are numerous ways to {{#link href="/support"}}Support Us{{/link}}!
+          The Ruby language could only have developed so robustly with its dedicated community. Our community consists of talented and passionate individual developers and many dynamic companies that recognize the value of helping foster a strong, sustainable environment for Ruby development. Join our {{#link href="/#/portal/signup"}}Member Community{{/link}}, <strong>Become a Sponsor</strong>, or {{#link href="/leadership"}}donate your time{{/link}} – there are numerous ways to {{#link href="/support"}}Support Us{{/link}}!
         </p>
-        <p></p>
-
+        <br>
         <p>
           If you are looking for ways to help or have questions, please contact us at {{#link href="mailto:contact@rubycentral.org"}}contact@rubycentral.org{{/link}}.
         </p>


### PR DESCRIPTION
🟢 - Ready, and real small
# Reason for Change
The Support section on the home page should contain a link to the Leadership page. 

For Reference: [Asana Task](https://app.asana.com/0/inbox/1202608190607057/1204927641840248/1204927782021149)

## Description of Change. 
Added the link. 