### PR TITLE
Hide particles when user prefers reduced motion

### DIFF
--- a/assets/particles/hideParticles.js
+++ b/assets/particles/hideParticles.js
@@ -1,0 +1,14 @@
+const reducedMotionMediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+function displayParticlesBasedOnMotionPreferences() {
+  if (reducedMotionMediaQuery.matches) {
+    particles.style.display = "none";
+  } else {
+    particles.style.display = "block";
+  }
+}
+
+displayParticlesBasedOnMotionPreferences();           // run on page ready
+reducedMotionMediaQuery.addEventListener(             // run on change
+  'change', displayParticlesBasedOnMotionPreferences
+);

--- a/default.hbs
+++ b/default.hbs
@@ -59,6 +59,7 @@
       </script>
       <div id="particles" style="position: fixed; top: 0; z-index: -10"></div>
       <script src="{{ asset "particles/hadron.d57b1908.js"}}"></script>
+      <script src="{{ asset "particles/hideParticles.js" }}"></script>
       {{!-- Outputs important scripts - should always be included before closing body tag --}}
       {{ghost_foot}}
     </body>


### PR DESCRIPTION
Just a thought based on #15. 

What if rather than fully remove the particles, we just hide the particles if the user prefers reduced motion.

I don't have a personal preference regarding the floaty particles. But I know some people strongly dislike them, and I can see a very valid accessibility argument. 
This is just 'one way' to meet people in the middle, and provide a way to get rid of the particles. 

### Description of Change
a sprinkle of javascript added to the default page template. 
- Determine if user prefers reduced motion. 
- Toggle the particles based on preference. 


#### A Preview
![Screen Recording 2023-09-28 at 10 10 46 PM](https://github.com/rubycentral/rubycentral-theme/assets/71521423/44e72196-4411-42fe-8da4-e079e3ed9c1c)

