### PR TITLE
Add Open Source Sponsors section to our home page

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -135,5 +135,18 @@
       {{/get}}
       </ul>
     </div>
+
+    <div id="oss-sponsors">
+      <h3>Open Source Sustaining Membership Sponsors</h3>
+      <ul class="people">
+      {{#get "pages" order="featured desc, title asc" filter="tags:hash-oss-sponsors" limit="all"}}
+        {{#foreach pages}}
+          {{> "person"}}
+        {{else}}
+          <p>Create a page for each open source major sponsor, title the post with the sponsor name, set the featured image to their profile picture (for logos, we need a square image for best results), and put an optional link in the page content. Add the tag <code>#oss-sponsors</code> for them to show up here.</p>
+        {{/foreach}}
+      {{/get}}
+      </ul>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
A couple of considerations here:
1. This is a mild mis-use of the CSS class "people" since these sponsors are not people. 
2. Relatedly, the circle CSS effect is not necessarily ideal in terms of making it easy for staff to upload Sponsor images. 

My current thinking is we can solve those issues in future iterations.

Note that we have an entry for "Sentry" on the ghost site, with the new tag added here, so I would expect this to autopopulate on merge and deploy.