### PR TITLE
Add top margin to sponsors section

### DIFF
--- a/src/css/rubycentral.css
+++ b/src/css/rubycentral.css
@@ -582,7 +582,7 @@ h3 {
   border-color: #3F6589;
 }
 
-#oss-team {
+#oss-team, #oss-sponsors {
   margin-top: 40px;
 }
 


### PR DESCRIPTION
Changes it from:
<img width="1225" alt="image" src="https://github.com/rubycentral/rubycentral-theme/assets/224488/8f0b8ecd-cb2c-42da-914b-053364d081bf">
to:
<img width="1167" alt="image" src="https://github.com/rubycentral/rubycentral-theme/assets/224488/ec9c48b0-10f4-4698-953d-95dd7f5e9af5">
