### PR TITLE
add all hbs files from root to the template

### DIFF
--- a/utils/zip.js
+++ b/utils/zip.js
@@ -1,6 +1,7 @@
 /*
 Use this script to create a zip file of your theme. Add or remove files you want to include.
 */
+const fs = require('fs');
 const AdmZip = require('adm-zip');
 
 const zip = new AdmZip();
@@ -10,12 +11,11 @@ zip.addLocalFolder('./assets', 'assets');
 zip.addLocalFolder('./partials', 'partials');
 
 // Files
-zip.addLocalFile('./author.hbs');
-zip.addLocalFile('./default.hbs');
-// zip.addLocalFile('./error-404.hbs');
-zip.addLocalFile('./home.hbs');
-zip.addLocalFile('./index.hbs');
+fs.readdirSync('./')
+  .filter((file) => file.endsWith('.hbs'))
+  .forEach((file) => zip.addLocalFile(`./${file}`));
+
 zip.addLocalFile('./package.json');
-zip.addLocalFile('./post.hbs');
 zip.addLocalFile('./README.md');
+
 zip.writeZip('./dist/theme.zip');


### PR DESCRIPTION
The theme.zip file didn't include `custom-support.hbs`. This updates the script to include all .hbs files, so the packaging script won't need to be updated for each new file in the future.