### PR TITLE
Circle post image should be object cover

### DIFF
--- a/src/css/rubycentral.css
+++ b/src/css/rubycentral.css
@@ -504,7 +504,7 @@ h3 {
   height: 200px;
   margin: 0 auto 1rem;
   width: 200px;
-  object-fit: fill;
+  object-fit: cover;
 }
 
 .people {


### PR DESCRIPTION
| Before | After |
|-|-|
| <img width="436" alt="Screenshot 2024-12-20 at 22 03 32" src="https://github.com/user-attachments/assets/d41206a7-cd02-4252-90c1-0c4b7c6494df" /> | <img width="436" alt="Screenshot 2024-12-20 at 22 03 36" src="https://github.com/user-attachments/assets/da409150-821c-4337-9d69-bdfd4f1a5946" /> |

I've only tested it on this single post, as it caught my eye.