### PR TITLE
Adjust Top Navigation Breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rubycentral-theme",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Ghost theme for Ruby Central",
   "engines": {
     "ghost": ">=4.0.0"

--- a/src/css/layout/navigation-top.css
+++ b/src/css/layout/navigation-top.css
@@ -108,14 +108,14 @@
         grid-area: membership;
     }
 
-    @media (min-width: 1440px) {
+    @media (min-width: 1080px) {
         .navigation__mobile-menu-trigger {
             display: none;
         }
 
         .navigation__inner {
             grid-template-columns: max-content 1fr max-content;
-            padding: 0;
+            padding: 0 20px 0 10px;
         }
 
         .navigation__logo {
@@ -143,6 +143,12 @@
 
         .navigation__list::before {
             display: none;
+        }
+    }
+
+    @media (min-width: 1440px) {
+        .navigation__inner {
+            padding: 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adjusts top navigation breakpoints to allow mobile menu to hide on small desktop devices.

## How I did it
* Changed the switch to desktop menu to `min-width: 1080px`
* Bumped version to `1.1.1`

## Results
<img width="1433" alt="Screenshot 2025-07-02 at 9 14 01 AM" src="https://github.com/user-attachments/assets/10f5a007-eedf-4f2c-83d9-b543168e954e" />
<img width="1433" alt="Screenshot 2025-07-02 at 9 14 17 AM" src="https://github.com/user-attachments/assets/7566ab9a-deec-43f1-bbc8-0f83b86677bc" />
