### PR TITLE
Mailchimp Newsletter Signups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rubycentral-theme",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A Ghost theme for Ruby Central",
   "engines": {
     "ghost": ">=4.0.0"

--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -10,12 +10,17 @@
             {{navigation type='secondary'}}
         </section>
         <section class='footer__bottom'>
-            <form class='footer__form' data-members-form='subscribe'>
+            <form
+                action='https://rubycentral.us13.list-manage.com/subscribe/post?u=e7e9b891a6914ff2f5acdfd15&amp;id=0a6a1336c5&amp;v_id=5118&amp;f_id=008ef4e7f0'
+                autocomplete='off'
+                class='footer__form'
+                method='post'
+            >
                 <div class='footer__form__row'>
                     <input
-                        data-members-email
-                        name='email'
-                        id='get-involved-email'
+                        data-lpignore='true'
+                        data-1p-ignore
+                        name='EMAIL'
                         placeholder='Enter your email...'
                         required='true'
                         type='email'
@@ -24,8 +29,6 @@
                         <button class='kg-btn' type='submit'>Sign Up</button>
                     </div>
                 </div>
-                <span data-members-error></span>
-                <span data-members-success></span>
             </form>
             <div class='footer__bottom__socials'>
                 <div class='footer__bottom__socials__links'>

--- a/partials/get-involved.hbs
+++ b/partials/get-involved.hbs
@@ -4,12 +4,17 @@
     <section class='get-involved__row'>
         <section class='get-involved__column--newsletter'>
             <p>Tune in to Ruby Central by<br />subscribing to our newsletter.</p>
-            <form class='get-involved__form' data-members-form='subscribe'>
+            <form
+                action='https://rubycentral.us13.list-manage.com/subscribe/post?u=e7e9b891a6914ff2f5acdfd15&amp;id=0a6a1336c5&amp;v_id=5118&amp;f_id=008ef4e7f0'
+                autocomplete='off'
+                class='get-involved__form'
+                method='post'
+            >
                 <div class='get-involved__form__row'>
                     <input
-                        data-members-email
-                        name='email'
-                        id='get-involved-email'
+                        data-lpignore='true'
+                        data-1p-ignore
+                        name='EMAIL'
                         placeholder='Enter your email...'
                         required='true'
                         type='email'
@@ -18,8 +23,6 @@
                         <button class='kg-btn' type='submit'>Sign Up</button>
                     </div>
                 </div>
-                <span data-members-error></span>
-                <span data-members-success></span>
             </form>
         </section>
         <section class='get-involved__column--content'>

--- a/src/css/components/get-involved.css
+++ b/src/css/components/get-involved.css
@@ -13,25 +13,6 @@
         margin: 0 auto 30px;
     }
 
-    span[data-members-error],
-    span[data-members-success] {
-        display: none;
-        font-size: 0.875rem;
-        font-weight: 700;
-        line-height: 1rem;
-        padding: 16px 0;
-    }
-
-    .error span[data-members-error] {
-        color: var(--color-darkred);
-        display: block;
-    }
-
-    .success span[data-members-success] {
-        color: green;
-        display: block;
-    }
-
     .get-involved__title {
         font-size: 2rem;
         font-weight: 500;
@@ -92,11 +73,6 @@
 
     @media (min-width: 834px) {
         padding: 96px 56px 0;
-
-        span[data-members-error],
-        span[data-members-success] {
-            text-align: center;
-        }
 
         .get-involved__title {
             font-size: 2.625rem;

--- a/src/css/layout/footer.css
+++ b/src/css/layout/footer.css
@@ -64,25 +64,6 @@
         align-items: center;
         display: flex;
         flex-direction: column;
-
-        span[data-members-error],
-        span[data-members-success] {
-            display: none;
-            font-size: 0.875rem;
-            font-weight: 700;
-            line-height: 1rem;
-            padding: 16px 0;
-        }
-    }
-
-    .error span[data-members-error] {
-        color: var(--color-darkred);
-        display: block;
-    }
-
-    .success span[data-members-success] {
-        color: green;
-        display: block;
     }
 
     .footer__form__row {


### PR DESCRIPTION
## Summary
This PR replaces Ghost newsletter forms with Mailchimp.

## How I did it
* Created a form in Mailchimp called `Website Signup Form` scoped to the `All contacts` audience
* Grabbed the `action` parameter and email input `name` from the `Website Signup Form`
  * Used those values in the Get Involved and Footer forms
* Bumped version to `1.1.2`

## Results
<img width="1717" alt="Screenshot 2025-07-02 at 11 28 33 PM" src="https://github.com/user-attachments/assets/fe571ad3-14eb-4a62-aa0a-5b1468968dd1" />